### PR TITLE
Fix layout error when bottom navigation bar is shown

### DIFF
--- a/ZeticLLMApps/ZeticLLMApp-Android/app/src/main/java/com/zeticai/zeticllmapps/MainActivity.kt
+++ b/ZeticLLMApps/ZeticLLMApp-Android/app/src/main/java/com/zeticai/zeticllmapps/MainActivity.kt
@@ -6,10 +6,14 @@ import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import android.widget.EditText
 import android.widget.ImageButton
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.zeticai.mlange.core.model.llm.ZeticMLangeLLMModel
@@ -24,8 +28,15 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
 
         recyclerView = findViewById(R.id.chatRecyclerView)
         messageInput = findViewById(R.id.messageInput)

--- a/ZeticLLMApps/ZeticLLMApp-Android/app/src/main/res/layout/activity_main.xml
+++ b/ZeticLLMApps/ZeticLLMApp-Android/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ZeticLLMApps/ZeticLLMApp-Android/app/src/main/res/values-night/themes.xml
+++ b/ZeticLLMApps/ZeticLLMApp-Android/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Zetic_mlange_android" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.Zetic_mlange_android" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/ZeticLLMApps/ZeticLLMApp-Android/app/src/main/res/values/themes.xml
+++ b/ZeticLLMApps/ZeticLLMApp-Android/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Zetic_mlange_android" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.Zetic_mlange_android" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>


### PR DESCRIPTION
### error
- when navigation bar is shown, app layout is displaying behind the navigation bar
- when open the keyboard, layout is not adjusted.

### fix
- `enableEdgeToEdge()`
- `ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main))`
- `window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)`